### PR TITLE
added /lime to the git clone path

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Because I’m just a single person and I don’t want to offer up my spare time 
 
 ```
 go get code.google.com/p/log4go github.com/quarnster/parser github.com/quarnster/completion github.com/howeyc/fsnotify
-git clone --recursive git@github.com:quarnster/lime.git $GOPATH/src
+git clone --recursive git@github.com:quarnster/lime.git $GOPATH/src/lime
 ```
 
 ### Modify cgo.go settings


### PR DESCRIPTION
If you would clone to `$GOPATH/src` it would just clone all files to that directory, without a `lime` sub-directory. Actually, git will throw an error saying that the directory already exists and that it's not empty.
