### PR TITLE
Added mercurial to the dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Because I like the architecture of the extensibilities in the original editor.
 - [cmake](http://cmake.org/)
 - Some form of build system that cmake can create a build system for (ninja, make, visual studio)
 - Git
+- Mercurial
 - Other required components will be downloaded as needed
 
 ### Download the needed repositories


### PR DESCRIPTION
Mercurial is required and has been added to the dependencies list in README.md.

See the following error:

Scanning dependencies of target lime
[ 78%] Generating ../../../pkg/linux_amd64/github.com/quarnster/parser.a
go: missing Mercurial command. See http://golang.org/s/gogetcmd
package github.com/quarnster/parser
        imports github.com/quarnster/util/text
        imports code.google.com/p/log4go: exec: "hg": executable file not found in $PATH
make[2]: **\* [../../../pkg/linux_amd64/github.com/quarnster/parser.a] Error 1
make[1]: **\* [CMakeFiles/lime.dir/all] Error 2
make: **\* [all] Error 2

Once mercurial was added (using debian / apt-get install mercurial):

$make
.
 (make proceeds to 100%)
.
$ make test
.
.
PASS
ok      lime/backend/sublime    2.882s
=== RUN TestTmLanguage
--- PASS: TestTmLanguage (0.86 seconds)
=== RUN TestLoadTheme
--- PASS: TestLoadTheme (0.00 seconds)
PASS
ok      lime/backend/textmate   0.875s
[100%] Built target test
$ 
