### PR TITLE
Fold build output in travis-ci

### DIFF
--- a/tasks/ci/lime.sh
+++ b/tasks/ci/lime.sh
@@ -1,6 +1,39 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+
+function fold_start {
+    if [ "$TRAVIS" == "true" ]; then
+        echo -en "travis_fold:start:$1\r"
+        echo "\$ $1"
+    fi
+}
+
+function fold_end {
+    if [ "$TRAVIS" == "true" ]; then
+        echo -en "travis_fold:end:$1\r"
+    fi
+}
 
 cd build
+
+fold_start "cmake"
 cmake ..
+fold_end "cmake"
+
+fold_start "make"
 make
+build_result=$?
+fold_end "make"
+
+# Print colored build result.
+RED="\e[31m"
+GREEN="\e[32m"
+YELLOW="\e[33m"
+RESET="\e[0m"
+echo -ne "${YELLOW}=>${RESET} BUILD - "
+if [ "$build_result" == "0" ]; then
+    echo -e "${GREEN}SUCCEEDED${RESET}"
+else
+    echo -e "${RED}FAILED${RESET}"
+fi
+
 make test


### PR DESCRIPTION
Another cosmetic PR :smile:
- `cmake` and `make` steps are folded to reduce visible output.
- Colored one-line summary of build result is printed.

This seriously improves the build output readabilty, without loosing something... we can always
unfold the `cmake` and `make` output whenever it is needed.

See it in action: [here](https://travis-ci.org/EdVanDance/lime/builds/14655098)
Inspired by: http://enricostano.github.io/articles/dealing-with-travis-ci-console-output/
