### PR TITLE
Use the `Settings` structs settingsMap directly

### DIFF
--- a/backend/editor.go
+++ b/backend/editor.go
@@ -48,6 +48,8 @@ type (
 	DummyFrontend struct{}
 )
 
+const SETTINGS_PATH = "../../backend/packages/Default/Default.sublime-settings"
+
 func (h *DummyFrontend) StatusMessage(msg string)      {}
 func (h *DummyFrontend) ErrorMessage(msg string)       {}
 func (h *DummyFrontend) MessageDialog(msg string)      {}
@@ -126,7 +128,7 @@ func (e *Editor) SetFrontend(f Frontend) {
 
 func (e *Editor) Init() {
 	ed.loadKeybindings()
-	ed.loadSettings()
+	ed.LoadSettings(SETTINGS_PATH)
 }
 
 func (e *Editor) loadKeybinding(fn string) {
@@ -149,21 +151,16 @@ func (e *Editor) loadKeybindings() {
 	e.loadKeybinding("../../3rdparty/bundles/Vintageous/Default.sublime-keymap")
 }
 
-func (e *Editor) loadSetting(fn string) {
-	d, err := ioutil.ReadFile(fn)
+func (e *Editor) LoadSettings(path string) {
+	d, err := ioutil.ReadFile(path)
 	if err != nil {
-		log4go.Error("Couldn't load file %s: %s", fn, err)
+		log4go.Error("Couldn't load file %s: %s", path, err)
 	}
-	if err := loaders.LoadJSON(d, e.Settings()); err != nil {
+	if err := loaders.LoadJSON(d, &e.Settings().Data); err != nil {
 		log4go.Error(err)
 	} else {
-		log4go.Info("Loaded %s", fn)
+		log4go.Info("Loaded %s", path)
 	}
-}
-
-func (e *Editor) loadSettings() {
-	// TODO(q): should search for settings
-	e.loadSetting("../../backend/packages/Default/Default.sublime-settings")
 }
 
 func (e *Editor) PackagesPath() string {

--- a/backend/editor_test.go
+++ b/backend/editor_test.go
@@ -1,0 +1,19 @@
+package backend
+
+import (
+	"testing"
+)
+
+func TestConfigLoading(t *testing.T) {
+	editor := GetEditor()
+	editor.LoadSettings("testdata/Default.sublime-settings")
+
+	if editor.Settings().Has("tab_size") != true {
+		t.Error("Expected editor settings to have tab_size")
+	}
+
+	tab_size := editor.Settings().Get("tab_size").(float64)
+	if tab_size != 4 {
+		t.Errorf("Expected tab_size to equal 4, got: %v", tab_size)
+	}
+}

--- a/backend/testdata/Default.sublime-settings
+++ b/backend/testdata/Default.sublime-settings
@@ -1,0 +1,4 @@
+{
+    // The number of spaces a tab is equal to. Valid values are powers of two: 2, 4, 8, 16
+    "tab_size": 4
+}


### PR DESCRIPTION
Previously the `Settings` struct was being passed into the
`loaders.LoadJSON` function, and that function was attempting to
unmarshal into it, as opposed to unmarshaling directly into the
underlying map. This change, along with a change proposed to
github.com/quarnster/util/text, allows for the settings to be properly
unmarshaled for later retrieval.
