### PR TITLE
Add line numbers to termbox frontend

### DIFF
--- a/backend/packages/Default/Default.sublime-settings
+++ b/backend/packages/Default/Default.sublime-settings
@@ -16,5 +16,8 @@
     "caret_blink": true,
 
     // How fast the blinking is performed if enabled
-    "caret_blink_phase": 1.0
+    "caret_blink_phase": 1.0,
+
+    // Whether to render line numbers
+    "line_numbers": true
 }

--- a/frontend/termbox/main_test.go
+++ b/frontend/termbox/main_test.go
@@ -1,0 +1,32 @@
+// Copyright 2013 The lime Authors.
+// Use of this source code is governed by a 2-clause
+// BSD-style license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestPadLineNumber(t *testing.T) {
+	var testPadData = []struct {
+		line     int
+		total    int
+		expected []rune
+	}{
+		{1, 3, []rune{' ', ' ', '1', ' '}},
+		{10, 3, []rune{' ', '1', '0', ' '}},
+		{100, 3, []rune{'1', '0', '0', ' '}},
+	}
+
+	for _, p := range testPadData {
+		runes := intToRunes(p.line)
+		padded := padLineRunes(runes, p.total)
+
+		for i, r := range p.expected {
+			if r != padded[i] {
+				t.Error("Expected runes to be padded")
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is a first pass implementation at adding line number rendering to
the termbox frontend. There is some refactoring I would like to do to
that entire part of the render loop as well as the line number rendering,
but I feel that would be best saved for another commit.

This PR addresses issue #164 
