### PR TITLE
Set blink to false so cursor seems more responsive

### DIFF
--- a/frontend/termbox/main.go
+++ b/frontend/termbox/main.go
@@ -568,7 +568,7 @@ func (t *tbfe) loop() {
 				}
 				ed.HandleInput(kp)
 
-				blink = true
+				blink = false
 			}
 			if len(evchan) > 0 {
 				limit--


### PR DESCRIPTION
Setting blink to false here makes the cursor seem much more responsive.
With blink set to true, the cursor disappears immediately following a
motion command and only reappears during the next `blink_phase` timeout.

This small change just makes the cursor not disappear, thus providing a
better editing experience with more immediate movement feedback.
