### PR TITLE
qml: Hookup keyboard

### DIFF
--- a/frontend/qml/main.go
+++ b/frontend/qml/main.go
@@ -19,6 +19,7 @@ import (
 	"lime/backend/sublime"
 	"lime/backend/textmate"
 	"lime/backend/util"
+	"runtime"
 	"sync"
 )
 
@@ -440,6 +441,43 @@ func (t *tbfe) loop() {
 
 	log4go.Debug("Done")
 	window.Wait()
+}
+
+func (t *tbfe) HandleInput(keycode int, modifiers int) bool {
+	log4go.Debug("tbfe.HandleInput: key=%x, modifiers=%x", keycode, modifiers)
+	shift := false
+	alt := false
+	ctrl := false
+	super := false
+
+	if key, ok := lut[keycode]; ok {
+		ed := backend.GetEditor()
+
+		if (modifiers & shift_mod) != 0 {
+			shift = true
+		}
+		if (modifiers & alt_mod) != 0 {
+			alt = true
+		}
+		if (modifiers & ctrl_mod) != 0 {
+			if runtime.GOOS == "darwin" {
+				super = true
+			} else {
+				ctrl = true
+			}
+		}
+		if (modifiers & meta_mod) != 0 {
+			if runtime.GOOS == "darwin" {
+				ctrl = true
+			} else {
+				super = true
+			}
+		}
+
+		ed.HandleInput(backend.KeyPress{Key: key, Shift: shift, Alt: alt, Ctrl: ctrl, Super: super})
+		return true
+	}
+	return false
 }
 
 func main() {

--- a/frontend/qml/main.qml
+++ b/frontend/qml/main.qml
@@ -16,6 +16,10 @@ ApplicationWindow {
     }
     Item {
         anchors.fill: parent
+        Keys.onPressed: {
+            event.accepted = frontend.handleInput(event.key, event.modifiers)
+        }
+        focus: true // Focus required for Keys.onPressed
         SplitView {
             anchors.fill: parent
             orientation: Qt.Vertical


### PR DESCRIPTION
So here is some basic keyboard handling.
Still some issues to solve:
1. Changes don't get drawed immediately, you have to scroll away and back again. (Should be part of another pr)
2. I am not sure how to handle the key/modifier combination properly. ATM pressing Shift+Z will
   send a `KeyPress{Key: 'z', Shift: true}`, but the editor does not convert that to uppercase `Z`. So
   in that case I should use the [KeyEvent.text](http://qt-project.org/doc/qt-5.1/qtquick/qml-qtquick2-keyevent.html#text-prop) property. 
   1. So how to decide whether to use the text only, the key/modifier combination or maybe even a combination of both?
   2. What KeyPress does the editor need to handle e.g.: "ctrl+shift+c"
3. ATM all key presses in the LUT are accepted, that means ALT+X for menu navigation
   would not work. What I would need is feedback whether something is bound to that key combination or not. If not
   it would pass the event to other widgets, by setting event.accepted = false.

First go code ever here, please help with idiomatic issues.

Looking forward to your comments.
