### PR TITLE
Refresh qml when the file name changed

### DIFF
--- a/frontend/qml/main.go
+++ b/frontend/qml/main.go
@@ -249,6 +249,7 @@ type (
 		bv            *backend.View
 		Len           int
 		FormattedLine []*lineStruct
+		Title         lineStruct
 	}
 )
 
@@ -302,10 +303,6 @@ func (t *tbfe) scroll(b Buffer, pos, delta int) {
 
 func (fv *frontendView) Line(index int) *lineStruct {
 	return fv.FormattedLine[index]
-}
-
-func (fv *frontendView) Title() string {
-	return fv.bv.Buffer().FileName()
 }
 
 func (fv *frontendView) Back() *backend.View {
@@ -439,10 +436,28 @@ func (t *tbfe) loop() {
 			}
 		})
 
+		fv.Title.Text = v.Buffer().FileName()
+		if len(fv.Title.Text) == 0 {
+			fv.Title.Text = "untitled"
+		}
+
 		w2 := t.windows[v.Window()]
 		w2.views = append(w2.views, fv)
 		w2.Len = len(w2.views)
 		t.qmlChanged(w2, &w2.Len)
+	})
+
+	backend.OnLoad.Add(func(v *backend.View) {
+		w2 := t.windows[v.Window()]
+		i := 0
+		for i, _ = range w2.views {
+			if w2.views[i].bv == v {
+				break
+			}
+		}
+		v2 := w2.views[i]
+		v2.Title.Text = v.Buffer().FileName()
+		t.qmlChanged(v2, &v2.Title)
 	})
 
 	ed := backend.GetEditor()

--- a/frontend/qml/main.qml
+++ b/frontend/qml/main.qml
@@ -78,7 +78,7 @@ ApplicationWindow {
                         }
                         model: tmp()
                         delegate: Tab {
-                            title: myWindow.view(index).title()
+                            title: myWindow.view(index).title.text
                             LimeView { myView: myWindow.view(index) }
                         }
                     }
@@ -115,7 +115,7 @@ ApplicationWindow {
                         id: minimapArea
                         y: parent.percentage(parent.children[1])*(parent.height-height)
                         width: parent.width
-                        height: parent.realView.visibleArea.heightRatio*parent.children[1].contentHeight
+                        height: parent.realView ? parent.realView.visibleArea.heightRatio*parent.children[1].contentHeight : parent.height
                         color: "white"
                         opacity: 0.1
                     }


### PR DESCRIPTION
The title of last tab was empty before. This is because the title is displayed when the number of tab is changed. Window.OpenFile will call NewFile first, and then set the file name. So we need to refresh it at the end of OpenFile function. I add a new callback function to the OnLoad event. 

This patch works on my machine.
