### PR TITLE
Add gofmt test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ install:
   - sudo apt-get install -qq libonig-dev mercurial python3.3 python3.3-dev
 
 script:
+  - ./tasks/ci/gofmt.sh
   - ./tasks/ci/lime.sh

--- a/tasks/ci/gofmt.sh
+++ b/tasks/ci/gofmt.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+fmt="$(find . ! \( -path './3rdparty' -prune \) -type f -name '*.go' -print0 | xargs -0 gofmt -l )"
+
+if [ -n "$fmt" ]; then
+    echo "Unformatted Go source code:"
+    echo "$fmt"
+    exit 1
+fi


### PR DESCRIPTION
This is a shot at #264 (I happen to have personal interest in this issue since I'm going to use the same script in my own projects). My shell scripting is nothing special, so if the script is questionable, I'm up for criticism.

Adding the script as a new line in .travis.yml (as opposed to adding it to the existing lime.sh) allows tests to continue even if gofmt fails, see [this](http://docs.travis-ci.com/user/customizing-the-build/#Customizing-the-Build-Step).
