### PR TITLE
Feature/reload settings

### DIFF
--- a/backend/editor.go
+++ b/backend/editor.go
@@ -165,6 +165,7 @@ func (e *Editor) loadSetting(path string) {
 		log4go.Error(err)
 	} else {
 		log4go.Info("Loaded %s", path)
+		e.Watch(NewWatchedSettingFile(path))
 	}
 }
 

--- a/backend/editor_test.go
+++ b/backend/editor_test.go
@@ -5,7 +5,9 @@
 package backend
 
 import (
+	"io/ioutil"
 	"testing"
+	"time"
 )
 
 type DummyWatchedFile struct {
@@ -41,5 +43,31 @@ func TestWatch(t *testing.T) {
 
 	if editor.watchedFiles["editor_test.go"] != observedFile {
 		t.Fatal("Expected editor to watch the specified file")
+	}
+}
+
+func TestWatchingSettings(t *testing.T) {
+	var path string = "testdata/Default.sublime-settings"
+	editor := GetEditor()
+	editor.loadSetting(path)
+
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal("Error in reading the default settings")
+	}
+
+	data := []byte("{\n\t\"tab_size\": 8\n}")
+	err = ioutil.WriteFile(path, data, 0644)
+	if err != nil {
+		t.Fatal("Error in writing to setting")
+	}
+	time.Sleep(time.Millisecond * 10)
+	if tab_size := editor.Settings().Get("tab_size").(float64); tab_size != 8 {
+		t.Errorf("Expected tab_size equal to 8, but got %v", tab_size)
+	}
+
+	err = ioutil.WriteFile(path, buf, 0644)
+	if err != nil {
+		t.Fatal("Error in writing the default back to setting")
 	}
 }

--- a/backend/watched.go
+++ b/backend/watched.go
@@ -19,6 +19,10 @@ type (
 	WatchedUserFile struct {
 		view *View
 	}
+
+	WatchedSettingFile struct {
+		path string
+	}
 )
 
 func NewWatchedUserFile(view *View) *WatchedUserFile {
@@ -41,4 +45,17 @@ func (o *WatchedUserFile) Reload() {
 		view.Replace(edit, Region{0, end}, string(d))
 		view.EndEdit(edit)
 	}
+}
+
+func NewWatchedSettingFile(path string) *WatchedSettingFile {
+	return &WatchedSettingFile{path}
+}
+
+func (o *WatchedSettingFile) Name() string {
+	return o.path
+}
+
+func (o *WatchedSettingFile) Reload() {
+	editor := GetEditor()
+	editor.loadSetting(o.path)
 }


### PR DESCRIPTION
Now we will detect all settings that are added with

```
editor.load(setting)
```

the test shows it works properly closes #220
