### PR TITLE
atomic save not working

### DIFF
--- a/backend/events_test.go
+++ b/backend/events_test.go
@@ -6,6 +6,7 @@ package backend
 
 import (
 	. "github.com/quarnster/util/text"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -50,5 +51,67 @@ func TestOnSelectionModified(t *testing.T) {
 	}
 	if !reflect.DeepEqual(res.Regions(), []Region{{3, 3}}) {
 		t.Errorf("%v", res.Regions())
+	}
+}
+
+func TestOnPreSave(t *testing.T) {
+	var testfile string = "testdata/test_event.txt"
+	var (
+		w         Window
+		v         = w.NewFile()
+		callCount = 0
+	)
+	OnPreSave.Add(func(v *View) {
+		callCount++
+	})
+	edit := v.BeginEdit()
+	v.Insert(edit, 0, "abcd")
+	v.EndEdit(edit)
+	if err := v.SaveAs(testfile); err != nil {
+		t.Fatal("Could not save the view")
+	}
+	if callCount != 1 {
+		t.Fatalf("%d != 1", callCount)
+	}
+	v.Buffer().SetFileName(testfile)
+	if err := v.Save(); err != nil {
+		t.Fatalf("Could not save the view %s", err)
+	}
+	if callCount != 2 {
+		t.Fatalf("%d != 2", callCount)
+	}
+	if err := os.Remove(testfile); err != nil {
+		t.Errorf("Couldn't remove test file %s", testfile)
+	}
+}
+
+func TestOnPostSave(t *testing.T) {
+	var testfile string = "testdata/test_event.txt"
+	var (
+		w         Window
+		v         = w.NewFile()
+		callCount = 0
+	)
+	OnPostSave.Add(func(v *View) {
+		callCount++
+	})
+	edit := v.BeginEdit()
+	v.Insert(edit, 0, "abcd")
+	v.EndEdit(edit)
+	if err := v.SaveAs(testfile); err != nil {
+		t.Fatal("Could not save the view")
+	}
+	if callCount != 1 {
+		t.Fatalf("%d != 1", callCount)
+	}
+	v.Buffer().SetFileName(testfile)
+	if err := v.Save(); err != nil {
+		t.Fatalf("Could not save the view: %s", err)
+	}
+	if callCount != 2 {
+		t.Fatalf("%d != 2", callCount)
+	}
+	if err := os.Remove(testfile); err != nil {
+		t.Errorf("Couldn't remove test file %s", testfile)
 	}
 }


### PR DESCRIPTION
There is a problem with atomic save when trying to `os.Rename(f.Name, name)` i get invalid cross-device link which is mentioned [here](https://groups.google.com/forum/#!topic/golang-dev/5w7Jmg_iCJQ) but using copy instead of rename will remove the advantage of atomic save.

Is there any alternative that we can still use atomic save?(maybe creating temp file in current buffer directory)
