### PR TITLE
Fixed window.Views() bug

### DIFF
--- a/backend/window.go
+++ b/backend/window.go
@@ -40,7 +40,7 @@ func (w *Window) NewFile() *View {
 func (w *Window) Views() []*View {
 	w.lock.Lock()
 	defer w.lock.Unlock()
-	ret := make([]*View, 0, len(w.views))
+	ret := make([]*View, len(w.views))
 	copy(ret, w.views)
 	return ret
 }

--- a/backend/window_test.go
+++ b/backend/window_test.go
@@ -1,0 +1,19 @@
+// Copyright 2013 The lime Authors.
+// Use of this source code is governed by a 2-clause
+// BSD-style license that can be found in the LICENSE file.
+
+package backend
+
+import (
+	"testing"
+)
+
+func TestNewFile(t *testing.T) {
+	ed := GetEditor()
+	w := ed.NewWindow()
+	w.NewFile()
+
+	if len(w.Views()) != 1 {
+		t.Errorf("Expected 1 view, but got %d", len(w.Views()))
+	}
+}


### PR DESCRIPTION
I was working on save_all and i realized that there is a problem with window returning the views. I wrote a test for that so others can see but i don't get why this is happening. why copy doesn't change the ret length
