### PR TITLE
Fixed watching on save as problem

### DIFF
--- a/backend/editor.go
+++ b/backend/editor.go
@@ -350,7 +350,7 @@ func (e *Editor) Watch(file WatchedFile) {
 }
 
 func (e *Editor) UnWatch(name string) {
-	delete(e.watchedFiles[name])
+	delete(e.watchedFiles, name)
 }
 
 func (e *Editor) observeFiles() {

--- a/backend/editor_test.go
+++ b/backend/editor_test.go
@@ -6,6 +6,7 @@ package backend
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 )
@@ -43,6 +44,34 @@ func TestWatch(t *testing.T) {
 
 	if editor.watchedFiles["editor_test.go"] != observedFile {
 		t.Fatal("Expected editor to watch the specified file")
+	}
+}
+
+func TestWatchOnSaveAs(t *testing.T) {
+	var testfile string = "testdata/Default.sublime-settings"
+	tests := []struct {
+		as string
+	}{
+		{
+			"User.sublime-settings",
+		},
+		{
+			"testdata/User.sublime-settings",
+		},
+	}
+	ed := GetEditor()
+	w := ed.NewWindow()
+	for i, test := range tests {
+		v := w.OpenFile(testfile, 0)
+		if err := v.SaveAs(test.as); err != nil {
+			t.Fatalf("Test %d: Can't save to `%s`: %s", i, test.as, err)
+		}
+		if _, exist := ed.watchedFiles[test.as]; !exist {
+			t.Errorf("Test %d: Should watch %s file", i, test.as)
+		}
+		if err := os.Remove(test.as); err != nil {
+			t.Errorf("Test %d: Couldn't remove test file %s", i, test.as)
+		}
 	}
 }
 

--- a/backend/view.go
+++ b/backend/view.go
@@ -535,9 +535,10 @@ func (v *View) SaveAs(name string) (err error) {
 		}
 	}
 
+	v.buffer.SetFileName(name)
 	ed := GetEditor()
 	ed.UnWatch(v.buffer.FileName())
-	ed.Watch(name)
+	ed.Watch(NewWatchedUserFile(v))
 
 	v.buffer.Settings().Set("lime.last_save_change_count", v.buffer.ChangeCount())
 	OnPostSave.Call(v)


### PR DESCRIPTION
The buffer filename should change  after save as and so i did it but something odd appeared the test passes fine on first go test but when i tested multiple times this error came out on some of them like 1 time in 4 time test

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x28 pc=0x43e1d6]

goroutine 9 [running]:
runtime.panic(0x609900, 0xacad28)
    /usr/lib/go/src/pkg/runtime/panic.c:266 +0xb6
_/home/mohammad/Projects/lime/backend.(*Editor).observeFiles(0xc21004c380)
    /home/mohammad/Projects/lime/backend/editor.go:361 +0xd6
created by _/home/mohammad/Projects/lime/backend.GetEditor
    /home/mohammad/Projects/lime/backend/editor.go:141 +0x3e6

goroutine 1 [chan receive]:
testing.RunTests(0x6c3288, 0xacae00, 0x15, 0x15, 0x1)
    /usr/lib/go/src/pkg/testing/testing.go:472 +0x8d5
testing.Main(0x6c3288, 0xacae00, 0x15, 0x15, 0xac5f80, ...)
    /usr/lib/go/src/pkg/testing/testing.go:403 +0x84
main.main()
    _/home/mohammad/Projects/lime/backend/_test/_testmain.go:91 +0x9c

goroutine 4 [chan receive]:
github.com/quarnster/util/text.(*SerializedBuffer).worker(0xc21006e248)
    /home/mohammad/.go/src/github.com/quarnster/util/text/serialized_buffer.go:39 +0x3e
created by github.com/quarnster/util/text.(*SerializedBuffer).init
    /home/mohammad/.go/src/github.com/quarnster/util/text/serialized_buffer.go:26 +0x87

goroutine 5 [syscall]:
syscall.Syscall(0x0, 0x3, 0xc21007e000, 0x10000, 0x1, ...)
    /usr/lib/go/src/pkg/syscall/asm_linux_amd64.s:18 +0x5
syscall.read(0x3, 0xc21007e000, 0x10000, 0x10000, 0x0, ...)
    /usr/lib/go/src/pkg/syscall/zsyscall_linux_amd64.go:838 +0x72
syscall.Read(0x3, 0xc21007e000, 0x10000, 0x10000, 0xc21006e148, ...)
    /usr/lib/go/src/pkg/syscall/syscall_unix.go:135 +0x5c
github.com/howeyc/fsnotify.(*Watcher).readEvents(0xc21004a300)
    /home/mohammad/.go/src/github.com/howeyc/fsnotify/fsnotify_linux.go:219 +0x109
created by github.com/howeyc/fsnotify.NewWatcher
    /home/mohammad/.go/src/github.com/howeyc/fsnotify/fsnotify_linux.go:126 +0x24d

goroutine 6 [chan send]:
github.com/howeyc/fsnotify.(*Watcher).purgeEvents(0xc21004a300)
    /home/mohammad/.go/src/github.com/howeyc/fsnotify/fsnotify.go:44 +0x202
created by github.com/howeyc/fsnotify.NewWatcher
    /home/mohammad/.go/src/github.com/howeyc/fsnotify/fsnotify_linux.go:127 +0x264

goroutine 7 [chan receive]:
_/home/mohammad/Projects/lime/backend.(*myLogWriter).handle(0xc2100000f8)
    /home/mohammad/Projects/lime/backend/editor.go:90 +0x48
created by _/home/mohammad/Projects/lime/backend.newMyLogWriter
    /home/mohammad/Projects/lime/backend/editor.go:85 +0x68

goroutine 8 [chan receive]:
_/home/mohammad/Projects/lime/backend.(*Editor).inputthread(0xc21004c380)
    /home/mohammad/Projects/lime/backend/editor.go:319 +0x96
created by _/home/mohammad/Projects/lime/backend.GetEditor
    /home/mohammad/Projects/lime/backend/editor.go:140 +0x3cc

goroutine 27 [runnable]:
code.google.com/p/log4go.Finest(0x5ae600, 0xc2100cc440, 0x0, 0x0, 0x0)
    /home/mohammad/.go/src/code.google.com/p/log4go/wrapper.go:109
_/home/mohammad/Projects/lime/backend.ViewEvent.Call(0x0, 0x0, 0x0, 0xc2100f6300)
    /home/mohammad/Projects/lime/backend/events.go:59 +0x63
_/home/mohammad/Projects/lime/backend.(*View).SaveAs(0xc2100f6300, 0x67da30, 0x17, 0x0, 0x0)
    /home/mohammad/Projects/lime/backend/view.go:544 +0x875
_/home/mohammad/Projects/lime/backend.(*View).Save(0xc2100f6300, 0x67da30, 0x17)
    /home/mohammad/Projects/lime/backend/view.go:488 +0x52
_/home/mohammad/Projects/lime/backend.TestOnPreSave(0xc2100e33f0)
    /home/mohammad/Projects/lime/backend/events_test.go:77 +0x3bd
testing.tRunner(0xc2100e33f0, 0xacae78)
    /usr/lib/go/src/pkg/testing/testing.go:391 +0x8b
created by testing.RunTests
    /usr/lib/go/src/pkg/testing/testing.go:471 +0x8b2

goroutine 14 [chan receive]:
_/home/mohammad/Projects/lime/backend.(*View).parsethread(0xc2100c1200)
    /home/mohammad/Projects/lime/backend/view.go:227 +0x92
created by _/home/mohammad/Projects/lime/backend.newView
    /home/mohammad/Projects/lime/backend/view.go:82 +0x13e

goroutine 15 [chan receive]:
github.com/quarnster/util/text.(*SerializedBuffer).worker(0xc21006e198)
    /home/mohammad/.go/src/github.com/quarnster/util/text/serialized_buffer.go:39 +0x3e
created by github.com/quarnster/util/text.(*SerializedBuffer).init
    /home/mohammad/.go/src/github.com/quarnster/util/text/serialized_buffer.go:26 +0x87

goroutine 16 [chan receive]:
_/home/mohammad/Projects/lime/backend.(*View).parsethread(0xc2100c1300)
    /home/mohammad/Projects/lime/backend/view.go:227 +0x92
created by _/home/mohammad/Projects/lime/backend.newView
    /home/mohammad/Projects/lime/backend/view.go:82 +0x13e

goroutine 17 [chan receive]:
github.com/quarnster/util/text.(*SerializedBuffer).worker(0xc2100de038)
    /home/mohammad/.go/src/github.com/quarnster/util/text/serialized_buffer.go:39 +0x3e
created by github.com/quarnster/util/text.(*SerializedBuffer).init
    /home/mohammad/.go/src/github.com/quarnster/util/text/serialized_buffer.go:26 +0x87

goroutine 25 [chan receive]:
_/home/mohammad/Projects/lime/backend.(*View).parsethread(0xc2100f6200)
    /home/mohammad/Projects/lime/backend/view.go:227 +0x92
created by _/home/mohammad/Projects/lime/backend.newView
    /home/mohammad/Projects/lime/backend/view.go:82 +0x13e

goroutine 26 [chan receive]:
github.com/quarnster/util/text.(*SerializedBuffer).worker(0xc2100e8248)
    /home/mohammad/.go/src/github.com/quarnster/util/text/serialized_buffer.go:39 +0x3e
created by github.com/quarnster/util/text.(*SerializedBuffer).init
    /home/mohammad/.go/src/github.com/quarnster/util/text/serialized_buffer.go:26 +0x87

goroutine 28 [chan receive]:
_/home/mohammad/Projects/lime/backend.(*View).parsethread(0xc2100f6300)
    /home/mohammad/Projects/lime/backend/view.go:227 +0x92
created by _/home/mohammad/Projects/lime/backend.newView
    /home/mohammad/Projects/lime/backend/view.go:82 +0x13e

goroutine 29 [chan receive]:
github.com/quarnster/util/text.(*SerializedBuffer).worker(0xc2100e82f8)
    /home/mohammad/.go/src/github.com/quarnster/util/text/serialized_buffer.go:39 +0x3e
created by github.com/quarnster/util/text.(*SerializedBuffer).init
    /home/mohammad/.go/src/github.com/quarnster/util/text/serialized_buffer.go:26 +0x87
exit status 2
```

Which it seems something is getting wrong in worker thread but i can't get it
