### PR TITLE
Added tooltips to qml viewer

### DIFF
--- a/frontend/qml/ToolTip.qml
+++ b/frontend/qml/ToolTip.qml
@@ -1,0 +1,67 @@
+import QtQuick 2.0
+import QtQuick.Controls 1.1
+import QtGraphicalEffects 1.0
+ 
+ 
+Item {
+    id: toolTipRoot
+    height: toolTipContainer.height
+    visible: false
+    clip: false
+    z: 999999999
+ 
+    property alias text: toolTip.text
+    property alias backgroundColor: content.color
+    property alias textColor: toolTip.color
+    property alias font: toolTip.font
+ 
+    function onMouseHover(x, y)
+    {
+        toolTipRoot.x = x;
+        toolTipRoot.y = y + 5;
+    }
+ 
+    function onVisibleStatus(flag)
+    {
+        toolTipRoot.visible = flag;
+    }
+ 
+    Component.onCompleted: {
+        var newObject = Qt.createQmlObject('import QtQuick 2.0; MouseArea {signal mouserHover(int x, int y); signal showChanged(bool flag); anchors.fill:parent; hoverEnabled: true; onPositionChanged: {mouserHover(mouseX, mouseY)} onEntered: {showChanged(true)} onExited:{showChanged(false)}}',
+            toolTipRoot.parent, "mouseItem");
+        newObject.mouserHover.connect(onMouseHover);
+        newObject.showChanged.connect(onVisibleStatus);
+    }
+ 
+    Item {
+        id: toolTipContainer
+        width: content.width + toolTipShadow.radius
+        height: content.height + toolTipShadow.radius
+ 
+        Rectangle {
+            id: content
+            width: toolTipRoot.width
+            height: toolTip.contentHeight + 10
+ 
+            Text {
+                id: toolTip
+                anchors {fill: parent; margins: 5}
+                wrapMode: Text.WrapAnywhere
+            }
+        }
+    }
+ 
+    DropShadow {
+        id: toolTipShadow
+        z: toolTipRoot.z
+        anchors.fill: source
+        cached: true
+        horizontalOffset: 4
+        verticalOffset: 4
+        radius: 8.0
+        samples: 16
+        color: "#80000000"
+        smooth: true
+        source: toolTipContainer
+    }
+}

--- a/frontend/qml/main.qml
+++ b/frontend/qml/main.qml
@@ -101,7 +101,20 @@ ApplicationWindow {
                         tab: Item {
                             implicitWidth: 180
                             implicitHeight: 28
+			     ToolTip {
+				    id: tooltip
+				    width: 550
+				    backgroundColor: "#BECCCC66"
+				    textColor: "black"
+				    font.pointSize: 8
+				    text: styleData.title
+				}
                             BorderImage {
+				     MouseArea {
+					 anchors.fill: parent
+					 hoverEnabled : true
+					 onEntered: console.log("entered")
+				     }
                                 source: styleData.selected ? "../../3rdparty/bundles/themes/soda/Soda Dark/tab-active.png" : "../../3rdparty/bundles/themes/soda/Soda Dark/tab-inactive.png"
                                 border { left: 5; top: 5; right: 5; bottom: 5 }
                                 width: 180
@@ -109,7 +122,7 @@ ApplicationWindow {
                                 Text {
                                     id: tab_title
                                     anchors.centerIn: parent
-                                    text: styleData.title
+                                    text: styleData.title.replace(/^.*[\\\/]/, '')
                                     color: frontend.defaultFg()
                                     anchors.verticalCenterOffset: 1
                                 }


### PR DESCRIPTION
This is my first contribution, so it may not be perfect. I couldn't get the software to build but I think that was due to modifications introduced in subsequent updates. It adds tooltips and limits the tab text to the filename instead of the whole path. The tooltip does show the whole path.
