### PR TITLE
Fix: indent blocks that selected reversely

### DIFF
--- a/backend/commands/indent.go
+++ b/backend/commands/indent.go
@@ -55,8 +55,8 @@ func (c *UnindentCommand) Run(v *View, e *Edit) error {
 	unindented_rows := map[int]struct{}{}
 	for i := 0; i < sel.Len(); i++ {
 		r := sel.Get(i)
-		start_row, _ := v.Buffer().RowCol(r.A)
-		end_row, _ := v.Buffer().RowCol(r.B)
+		start_row, _ := v.Buffer().RowCol(r.Begin())
+		end_row, _ := v.Buffer().RowCol(r.End())
 		for row := start_row; row <= end_row; row++ {
 			if _, ok := unindented_rows[row]; !ok {
 				pos := v.Buffer().TextPoint(row, 0)

--- a/backend/commands/indent_test.go
+++ b/backend/commands/indent_test.go
@@ -115,6 +115,14 @@ func TestUnindent(t *testing.T) {
 			[]Region{{0, 1}, {11, 12}},
 			"a\n b\n  c\n\t   d\n",
 		},
+		{ // region selected reversely
+			// should perform unindent
+			"\ta\n\t b\n  c\n   d\n",
+			false,
+			4,
+			[]Region{{3, 0}},
+			"a\n b\n  c\n   d\n",
+		},
 	}
 
 	runTest(t, tests, "unindent")


### PR DESCRIPTION
Blocks that selected reversely cannot be indented in the old code.
