### PR TITLE
Report coverage on success

### DIFF
--- a/tasks/ci/lime.sh
+++ b/tasks/ci/lime.sh
@@ -89,7 +89,7 @@ fail2=$build_result
 
 let ex=$fail1+$fail2
 
-if [ "$build_result" == "0" ]; then
+if [ "$ex" == "0" ]; then
 	"$(go env GOPATH | awk 'BEGIN{FS=":"} {print $1}')/bin/goveralls" -coverprofile=coverage.cov -service=travis-ci
 fi
 


### PR DESCRIPTION
Currently the coverage reports are misleading when a build fails, because they're missing some of the tests.

Also cause the build to be marked as a failure if the coverage tests fail.
