### PR TITLE
Improve tasks/ci/lime.sh

### DIFF
--- a/tasks/ci/lime.sh
+++ b/tasks/ci/lime.sh
@@ -42,7 +42,7 @@ function do_test {
 	for pkg in $(go list "./$1/..."); do
 		do_test2 "$pkg"
 		let a=$a+$build_result
-		if [ -f tmp.cov ]; then
+		if [ "$build_result" == "0" ]; then
 			sed 1d tmp.cov >> coverage.cov
 		fi
 	done


### PR DESCRIPTION
Remove a Useless Use of Cat.
Stop complaining about missing coverage files when a build is failing.
