### PR TITLE
Fix some glitchy output in termbox frontend

### DIFF
--- a/frontend/termbox/main.go
+++ b/frontend/termbox/main.go
@@ -6,7 +6,6 @@ package main
 import (
 	"code.google.com/p/log4go"
 	"flag"
-	"fmt"
 	"github.com/limetext/gopy/lib"
 	"github.com/limetext/lime/backend"
 	_ "github.com/limetext/lime/backend/commands"
@@ -192,10 +191,6 @@ func (t *tbfe) renderView(v *backend.View, lay layout) {
 			termbox.SetCell(x, y, r, fg, bg)
 		}
 		x++
-	}
-
-	if t.settings.lineNumbers {
-		renderLineNumber(&line, &x, y, lineNumberRenderSize, fg, bg)
 	}
 
 	// restore original caretStyle before blink modification
@@ -413,7 +408,7 @@ func (t *tbfe) loop() {
 	evchan := make(chan termbox.Event, 32)
 	defer func() {
 		close(evchan)
-		fmt.Println(util.Prof)
+		log4go.Debug(util.Prof)
 	}()
 
 	go func() {
@@ -644,7 +639,7 @@ func setSchemeSettings() {
 			if col, ok := s.Settings[setting]; ok {
 				i := palLut(col)
 				if setting == "selection" {
-					fmt.Println(col, i)
+					log4go.Debug("%+v, %d", col, i)
 				}
 			}
 		}


### PR DESCRIPTION
There were a few fmt.Printf's, as well as a faulty call to renderLineNumber in the termbox frontend.

One caused random data to be dumped on the screen that termbox wasn't aware of, and therefore would persist. The other caused a glitchy first line number. It was making me twitch.

Although, admittedly, I'm not sure what the point of the last debug log was (in setSchemeSettings). I left it in for now, just in case someone felt it was needed. If palLut didn't have the occassional sideeffect of changing color palettes, I'd remove the entire "if col, ok" block, as it seems rather redundant.
