### PR TITLE
Implemented expand_by_class. Closes #362.

### DIFF
--- a/backend/sublime/testdata/api.txt
+++ b/backend/sublime/testdata/api.txt
@@ -252,6 +252,7 @@ View
 	end_edit
 	erase
 	erase_regions
+	expand_by_class
 	extract_scope
 	file_name
 	find_by_class

--- a/backend/sublime/testdata/view_test.py
+++ b/backend/sublime/testdata/view_test.py
@@ -30,6 +30,23 @@ hocus pocus
     assert v.sel()[0] == (45, 45)
     v.run_command("move", {"by": "characters", "forward": True})
     assert v.sel()[0] == (46, 46)
+
+    v2 = sublime.test_window.new_file()
+    e = v2.begin_edit()
+    v2.insert(e, 0, """one word { another word }
+line
+
+after empty line""")
+    v2.end_edit(e)
+    # Expected results validated in Sublime
+    assert v2.find_by_class(1, True, sublime.CLASS_WORD_START) == sublime.Region(4, 4)
+    assert v2.find_by_class(1, True, sublime.CLASS_PUNCTUATION_START) == sublime.Region(9, 9)
+    assert v2.expand_by_class(sublime.Region(5, 6),
+    	sublime.CLASS_WORD_START | sublime.CLASS_WORD_END) == sublime.Region(4, 8)
+    assert v2.expand_by_class(sublime.Region(11, 12),
+    	sublime.CLASS_PUNCTUATION_START | sublime.CLASS_PUNCTUATION_END) == sublime.Region(10, 24)
+    assert v2.expand_by_class(sublime.Region(5, 6), sublime.CLASS_EMPTY_LINE) == sublime.Region(0, 31)
+
 except:
     print(sys.exc_info()[1])
     traceback.print_exc()

--- a/backend/sublime/view_manual.go
+++ b/backend/sublime/view_manual.go
@@ -267,3 +267,49 @@ func (o *View) Py_set_syntax_file(tu *py.Tuple) (py.Object, error) {
 	}
 	return toPython(nil)
 }
+
+func (o *View) Py_expand_by_class(tu *py.Tuple, kw *py.Dict) (py.Object, error) {
+	var (
+		arg1 text.Region
+		arg2 int
+	)
+
+	if v, err := tu.GetItem(0); err != nil {
+		return nil, err
+	} else {
+		if v2, ok := v.(*Region); !ok {
+			if v2, ok := v.(*py.Long); !ok {
+				return nil, fmt.Errorf("Expected type *Region or *Int for backend.View.ExpandByClass() arg1, not %s", v.Type())
+			} else {
+				arg1.A = int(v2.Int64())
+				arg1.B = arg1.A + 1
+			}
+		} else {
+			arg1 = v2.data
+		}
+	}
+
+	if v, err := tu.GetItem(1); err != nil {
+		return nil, err
+	} else {
+		if v3, err2 := fromPython(v); err2 != nil {
+			return nil, err2
+		} else {
+			if v2, ok := v3.(int); !ok {
+				return nil, fmt.Errorf("Expected type int for backend.View.ExpandByClass() arg2, not %s", v.Type())
+			} else {
+				arg2 = v2
+			}
+		}
+	}
+
+	ret := o.data.ExpandByClass(arg1, arg2)
+	var err error
+	var pyret py.Object
+
+	pyret, err = toPython(ret)
+	if err != nil {
+		return nil, err
+	}
+	return pyret, err
+}

--- a/backend/view_test.go
+++ b/backend/view_test.go
@@ -456,6 +456,20 @@ func TestFindByClass(t *testing.T) {
 			CLASS_SUB_WORD_START,
 			Region{4, 4},
 		},
+		{
+			"abc Hi -test lime",
+			9,
+			false,
+			CLASS_WORD_END | CLASS_PUNCTUATION_END,
+			Region{8, 8},
+		},
+		{
+			"abc Hi -test lime",
+			0,
+			true,
+			CLASS_WORD_START | CLASS_WORD_END,
+			Region{3, 3},
+		},
 	}
 
 	for i, test := range tests {
@@ -465,6 +479,57 @@ func TestFindByClass(t *testing.T) {
 		v.EndEdit(e)
 		if res := v.FindByClass(test.point, test.forward, test.classes); res != test.expect {
 			t.Errorf("Test %d: Expected %d from view.FindByClass but, got %d", i, test.expect, res)
+		}
+	}
+}
+
+func TestExpandByClass(t *testing.T) {
+	var w Window
+	tests := []struct {
+		text    string
+		start   Region
+		classes int
+		expect  Region
+	}{
+		{
+			"abc Hi -test lime",
+			Region{1, 2},
+			CLASS_WORD_START,
+			Region{0, 4},
+		},
+		{
+			"abc Hi -test lime",
+			Region{8, 10},
+			CLASS_WORD_START | CLASS_WORD_END,
+			Region{6, 12},
+		},
+		{
+			"abc Hi -test lime",
+			Region{12, 14},
+			CLASS_PUNCTUATION_START,
+			Region{7, 17},
+		},
+		{
+			"abc Hi -test lime",
+			Region{12, 14},
+			CLASS_PUNCTUATION_END,
+			Region{8, 17},
+		},
+		{
+			"abc Hi -test lime",
+			Region{9, 11},
+			CLASS_WORD_START | CLASS_WORD_END,
+			Region{8, 12},
+		},
+	}
+
+	for i, test := range tests {
+		v := w.NewFile()
+		e := v.BeginEdit()
+		v.Insert(e, 0, test.text)
+		v.EndEdit(e)
+		if res := v.ExpandByClass(test.start, test.classes); res != test.expect {
+			t.Errorf("Test %d: Expected %v from view.ExpandByClass, but got %v", i, test.expect, res)
 		}
 	}
 }


### PR DESCRIPTION
 Optional argument separators requires changes Classify and FindByClass (not currently implemented for find_by_class either), will be implemented later. Will require implementing Py_find_by_class manually.
