### PR TITLE
Make sure that that termbox is set up before renderThread starts.

### DIFF
--- a/frontend/termbox/main.go
+++ b/frontend/termbox/main.go
@@ -419,7 +419,7 @@ func (t *tbfe) loop() {
 	setSchemeSettings()
 
 	// We start the renderThread here, after we have done our setup of termbox.
-	// That we, we do not clash with our output.
+	// That way, we do not clash with our output.
 	go t.renderthread()
 
 	evchan := make(chan termbox.Event, 32)


### PR DESCRIPTION
While we should probably ensure proper locking/queing around termbox, this is a "quick fix" that ensures that termbox has been inited before renderThread is started, which will otherwise have race to see who can dump things the fastest to stdout - a race with no winner due to mangled output.

Edit: By inited, I mean that SetColorMode and others have been completed, so that only renderThread has responsibility of termbox. (Apart from the deferred Close)
