### PR TITLE
Minor stuff

### DIFF
--- a/frontend/termbox/main.go
+++ b/frontend/termbox/main.go
@@ -409,7 +409,7 @@ func (t *tbfe) loop() {
 	c.Buffer().AddCallback(t.scroll)
 
 	t.setupCallbacks(v)
-	path := "../../3rdparty/bundles/TextMate-Themes/GlitterBomb.tmTheme"
+	path := "../../3rdparty/bundles/TextMate-Themes/Monokai.tmTheme"
 	if sc, err := textmate.LoadTheme(path); err != nil {
 		log4go.Error(err)
 		return


### PR DESCRIPTION
Contains:
- rotateLog flag
- A saved Lock
- Nicer channel use
- Monokai default theme
- A quick fix for log4go dumping util.Prof to the console after termbox has shut down the alternate screen, giving some rather borked output.

Everything contained in individual commits for easy handling.
