### PR TITLE
html: Implement Port Flag

### DIFF
--- a/frontend/html/main.go
+++ b/frontend/html/main.go
@@ -27,8 +27,8 @@ import (
 )
 
 var (
-	scheme   *textmate.Theme
-	blink    bool
+	scheme *textmate.Theme
+	blink  bool
 	port   = flag.Int("port", 8080, "Configures which port to host lime on")
 )
 


### PR DESCRIPTION
The flag is initialized with the default value of 8080; may be changed by calling it with -port <number>.
