### PR TITLE
First move in isolating logic

### DIFF
--- a/frontend/termbox/main.go
+++ b/frontend/termbox/main.go
@@ -115,7 +115,55 @@ type tbfe struct {
 	layout         map[*backend.View]layout
 	status_message string
 	dorender       chan bool
+	shutdown       chan bool
 	lock           sync.Mutex
+	editor         *backend.Editor
+	console        *backend.View
+	currentView    *backend.View
+	currentWindow  *backend.Window
+}
+
+// Creates and initializes the frontend.
+func createFrontend() *tbfe {
+	var t tbfe
+	t.dorender = make(chan bool, render_chan_len)
+	t.shutdown = make(chan bool, 2)
+	t.layout = make(map[*backend.View]layout)
+
+	t.editor = t.setupEditor()
+	t.console = t.editor.Console()
+	t.currentWindow = t.editor.NewWindow()
+
+	// Assuming that all extra arguments are files
+	if files := flag.Args(); len(files) > 0 {
+		for _, file := range files {
+			t.currentView = createNewView(file, t.currentWindow)
+		}
+	} else {
+		t.currentView = t.currentWindow.NewFile()
+	}
+
+	t.console.Buffer().AddCallback(t.scroll)
+	t.setupCallbacks(t.currentView)
+
+	path := "../../3rdparty/bundles/TextMate-Themes/Monokai.tmTheme"
+	if sc, err := textmate.LoadTheme(path); err != nil {
+		log4go.Error(err)
+	} else {
+		scheme = sc
+	}
+
+	setColorMode()
+	setSchemeSettings()
+
+	w, h := termbox.Size()
+	t.handleResize(h, w, true)
+
+	// These might take a while
+	t.editor.Init()
+	go sublime.Init()
+
+	return &t
 }
 
 func (t *tbfe) renderView(v *backend.View, lay layout) {
@@ -371,7 +419,7 @@ func (t *tbfe) renderthread() {
 
 		w, h := termbox.Size()
 		for i := 0; i < w && i < len(runes); i++ {
-			termbox.SetCell(i, h-1, runes[i], defaultFg, defaultBg)
+			termbox.SetCell(i, h-2, runes[i], defaultFg, defaultBg)
 		}
 
 		for i, v := range vs {
@@ -388,146 +436,115 @@ func (t *tbfe) renderthread() {
 	}
 }
 
-func (t *tbfe) loop() {
-
-	var (
-		ed = t.setupEditor()
-		c  = ed.Console()
-		w  = ed.NewWindow()
-		v  *backend.View
-	)
-
-	// Assuming that all extra arguments are files
-	if files := flag.Args(); len(files) > 0 {
-		for _, file := range files {
-			v = createNewView(file, w)
+func (t *tbfe) handleResize(height, width int, init bool) {
+	// This should handle multiple views in a less hardcoded fashion.
+	// After all, it is possible to *not* have a view in a window.
+	if init {
+		t.layout[t.currentView] = layout{0, 0, 0, 0, Region{}, 0}
+		if *showConsole {
+			t.layout[t.console] = layout{0, 0, 0, 0, Region{}, 0}
 		}
-	} else {
-		v = w.NewFile()
 	}
 
-	c.Buffer().AddCallback(t.scroll)
+	if *showConsole {
+		view_layout := t.layout[t.currentView]
+		view_layout.height = height - *consoleHeight - 4
+		view_layout.width = width
 
-	t.setupCallbacks(v)
-	path := "../../3rdparty/bundles/TextMate-Themes/Monokai.tmTheme"
-	if sc, err := textmate.LoadTheme(path); err != nil {
-		log4go.Error(err)
+		console_layout := t.layout[t.console]
+		console_layout.y = height - *consoleHeight - 2
+		console_layout.width = width
+		console_layout.height = *consoleHeight - 1
+
+		t.layout[t.console] = console_layout
+		t.layout[t.currentView] = view_layout
+	} else {
+		view_layout := t.layout[t.currentView]
+		view_layout.height = height - 3
+		view_layout.width = width
+		t.layout[t.currentView] = view_layout
+	}
+
+	// Ensure that the new visible region is recalculated
+	t.Show(t.currentView, t.VisibleRegion(t.currentView))
+}
+
+func (t *tbfe) handleInput(ev termbox.Event) {
+	if ev.Key == termbox.KeyCtrlQ {
+		t.shutdown <- true
+	}
+
+	var kp backend.KeyPress
+	if ev.Ch != 0 {
+		kp.Key = backend.Key(ev.Ch)
+	} else if v2, ok := lut[ev.Key]; ok {
+		kp = v2
+	} else {
 		return
-	} else {
-		scheme = sc
 	}
-	setColorMode()
-	setSchemeSettings()
 
-	// We start the renderThread here, after we have done our setup of termbox.
-	// That way, we do not clash with our output.
-	go t.renderthread()
+	t.editor.HandleInput(kp)
+}
 
-	evchan := make(chan termbox.Event, 32)
-	defer func() {
-		close(evchan)
+func (t *tbfe) loop() {
+	var timer time.Timer
+
+	timechan := make(chan bool, 0)
+	defer func(){
+		// By stopping the timer, we can safely close timechan
+		timer.Stop()
+		close(timechan)
 	}()
 
+	go func() {
+		// This should somehow be changable on an OnSettingsChanged callback
+		if p := t.editor.Settings().Get("caret_blink", true).(bool); !p {
+			return
+		}
+
+		duration := time.Second / 2
+		if p, ok := t.editor.Settings().Get("caret_blink_phase", 1.0).(float64); ok {
+			duration = time.Duration(float64(time.Second)*p) / 2
+		}
+		timer.Reset(duration)
+		for _ = range timer.C {
+			timechan <- true
+			timer.Reset(duration)
+		}
+	}()
+
+	// Due to termbox still running, we can't close evchan
+	evchan := make(chan termbox.Event, 32)
 	go func() {
 		for {
 			evchan <- termbox.PollEvent()
 		}
 	}()
 
-	{
-		w, h := termbox.Size()
-		t.lock.Lock()
-		if *showConsole {
-			t.layout[v] = layout{0, 0, w, h - *consoleHeight - 4, Region{}, 0}
-			t.layout[c] = layout{0, h - *consoleHeight - 2, w, *consoleHeight - 1, Region{}, 0}
-		} else {
-			t.layout[v] = layout{0, 0, w, h - 3, Region{}, 0}
-		}
-		t.lock.Unlock()
-		t.Show(v, Region{1, 1})
-	}
-	t.Show(v, Region{100, 100})
-	t.Show(v, Region{1, 1})
-
-	go func() {
-		ed.Init()
-		sublime.Init()
-	}()
-
 	for {
 		p := util.Prof.Enter("mainloop")
-
-		blink_phase := time.Second
-		if p, ok := ed.Settings().Get("caret_blink_phase", 1.0).(float64); ok {
-			blink_phase = time.Duration(float64(time.Second) * p)
-		}
-
-		// Divided by two since we're only doing a simple toggle blink
-		timer := time.NewTimer(blink_phase / 2)
 		select {
 		case ev := <-evchan:
 			mp := util.Prof.Enter("evchan")
-			limit := 3
-		loop:
 			switch ev.Type {
 			case termbox.EventError:
 				log4go.Debug("error occured")
 				return
 			case termbox.EventResize:
-				// We have to resize our layouts...
-				// There is currently duplicate code for calculating the layout:
-				// during initialization (above), and here. Not nice
-				if *showConsole {
-					view_layout := t.layout[v]
-					view_layout.height = ev.Height - *consoleHeight - 4
-					view_layout.width = ev.Width
-
-					console_layout := t.layout[c]
-					console_layout.y = ev.Height - *consoleHeight - 2
-					console_layout.width = ev.Width
-
-					t.layout[v] = view_layout
-					t.layout[c] = console_layout
-				} else {
-					view_layout := t.layout[v]
-					view_layout.height = ev.Height - 3
-					view_layout.width = ev.Width
-					t.layout[v] = view_layout
-				}
-
-				// Ensure that the new visible region is recalculated
-				t.Show(v, t.VisibleRegion(v))
+				t.handleResize(ev.Height, ev.Width, false)
 			case termbox.EventKey:
-				var kp backend.KeyPress
-
-				if ev.Ch != 0 {
-					kp.Key = backend.Key(ev.Ch)
-				} else if v2, ok := lut[ev.Key]; ok {
-					kp = v2
-				} else {
-					break
-				}
-
-				if ev.Key == termbox.KeyCtrlQ {
-					return
-				}
-				ed.HandleInput(kp)
-
+				t.handleInput(ev)
 				blink = false
 			}
-			if len(evchan) > 0 {
-				limit--
-				ev = <-evchan
-				goto loop
-			}
 			mp.Exit()
-		case <-timer.C:
-			// TODO(q): Shouldn't redraw if blink is disabled...
 
+		case <-timechan:
 			blink = !blink
 			t.render()
+
+		case <-t.shutdown:
+			return
 		}
-		timer.Stop()
 		p.Exit()
 	}
 }
@@ -688,6 +705,7 @@ func main() {
 	if err := termbox.Init(); err != nil {
 		log4go.Exit(err)
 	}
+
 	defer func() {
 		termbox.Close()
 		log4go.Debug(util.Prof)
@@ -696,8 +714,7 @@ func main() {
 		}
 	}()
 
-	var t tbfe
-	t.dorender = make(chan bool, render_chan_len)
-	t.layout = make(map[*backend.View]layout)
+	t := createFrontend()
+	go t.renderthread()
 	t.loop()
 }

--- a/frontend/termbox/main_test.go
+++ b/frontend/termbox/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/limetext/termbox-go"
 	. "github.com/quarnster/util/text"
 	"testing"
+	"time"
 )
 
 func TestPadLineRunes(t *testing.T) {
@@ -80,5 +81,70 @@ func TestUpdateVisibleRegion(t *testing.T) {
 
 	if end := fe.layout[v].visible.End(); end != 3 {
 		t.Fatalf("Expected 3, got %d", end)
+	}
+}
+
+func TestCreateFrontend(t *testing.T) {
+	var frontend *tbfe
+	frontendWasCreated := make(chan bool, 0)
+	go func(){
+		frontend = createFrontend()
+		frontendWasCreated <- true
+	}()
+
+	select {
+	case <-frontendWasCreated:
+		break
+	case <-time.After(2 * time.Second):
+		t.Error("Frontend was not created within timeout")
+	}
+
+	*showConsole = true
+	if frontend.editor == nil {
+		t.Error("Editor is nil")
+	}
+
+	if frontend.console == nil {
+		t.Error("Current console is nil")
+	}
+
+	if frontend.currentWindow == nil {
+		t.Error("Current window is nil")
+	}
+
+	if frontend.currentView == nil {
+		t.Error("Current view is nil")
+	}
+
+	if _, ok := frontend.layout[frontend.currentView]; !ok {
+		t.Error("Current view not in layout")
+	}
+
+	if _, ok := frontend.layout[frontend.console]; !ok {
+		t.Error("Console view not in layout")
+	}
+
+	if len(frontend.layout) != 2 {
+		t.Error("Layout too big")
+	}
+
+}
+
+func TestLoopShutdown(t *testing.T) {
+	frontend := createFrontend()
+
+	loopHasExited := make(chan bool, 0)
+	go func() {
+		frontend.loop()
+		loopHasExited <- true
+	}()
+
+	frontend.shutdown <- true
+
+	select {
+	case <-loopHasExited:
+		break
+	case <-time.After(2 * time.Second):
+		t.Error("Loop did not terminate within timeout")
 	}
 }


### PR DESCRIPTION
I removed the setup, resize and input logic from loop, so it only sets up and listens on its channels. createFrontend should see further reduction in the future.

Unittests slightly expanded, although they contain rather "stupid" tests. I wasn't particularly creative there.

I hope this is good enough as a "first step towards simple logic and unittestability". I am happy to hear if there are any ideas or criticism towards my approach.
