### PR TITLE
added an window title to the ApplicationWindow

### DIFF
--- a/frontend/qml/main.qml
+++ b/frontend/qml/main.qml
@@ -11,6 +11,7 @@ ApplicationWindow {
     id: window
     width: 800
     height: 600
+    title: "Lime"
 
     property var myWindow
 


### PR DESCRIPTION
later this can be changed to "/path/to/file.go - Lime", but for now I think this is ok because If I use lime it has no Window title and this looks a little bit bad :smile: 
