### PR TITLE
Clean up termbox frontend code

### DIFF
--- a/frontend/termbox/main.go
+++ b/frontend/termbox/main.go
@@ -234,8 +234,6 @@ func (t *tbfe) renderView(v *backend.View, lay layout) {
 			x = sx
 			if y++; y > ey {
 				break
-			} else if lineNumbers {
-				renderLineNumber(&line, &x, y, lineNumberRenderSize, fg, bg)
 			}
 			continue
 		}


### PR DESCRIPTION
This fixes https://github.com/limetext/lime/issues/376 By default on a new line, no line number is printed and the editor is out of place. This is due to a missing piece of code that prints the line number after a newline is detected. I've also cleaned up some code throughout the file because it was bothering me.
