### PR TITLE
Fix fg/bg for newline lineno render. Added comment about redundant calls.

### DIFF
--- a/frontend/termbox/main.go
+++ b/frontend/termbox/main.go
@@ -250,7 +250,10 @@ func (t *tbfe) renderView(v *backend.View, lay layout) {
 			if y++; y > ey {
 				break
 			} else if lineNumbers {
-				renderLineNumber(&line, &x, y, lineNumberRenderSize, fg, bg)
+				// This results in additional calls to renderLineNumber.
+				// Maybe just accumulate positions needing line numbers, rendering them
+				// after the loop?
+				renderLineNumber(&line, &x, y, lineNumberRenderSize, defaultFg, defaultBg)
 			}
 			continue
 		}


### PR DESCRIPTION
This fixes the attributes used by the extra call to renderLineNumber, fixing #469.

I also added a comment about the redundant calls to renderLineNumber: Every line with content that isn't the last in the view will have renderLineNumber called twice. That tickles my OCD's, and my OCD's hate being tickled.
