### PR TITLE
add test case for empty string in backend/commands/indent_test.go

### DIFF
--- a/backend/commands/indent_test.go
+++ b/backend/commands/indent_test.go
@@ -153,6 +153,14 @@ func TestUnindent(t *testing.T) {
 			[]Region{{3, 0}},
 			"a\n b\n  c\n   d\n",
 		},
+		{ // empty strings
+			// should perform unindent
+			"",
+			false,
+			nil,
+			[]Region{{0, 0}},
+			"",
+		},
 	}
 
 	runIndentTest(t, tests, "unindent")


### PR DESCRIPTION
Tests case for empty string and brings indent.go test coverage to 100%.

If not merged, please give feedback.