### PR TITLE
add l.Errorf(...) to TestLogFunctions(t *testing.T) in backend/log/logger_test.go

### DIFF
--- a/backend/log/logger_test.go
+++ b/backend/log/logger_test.go
@@ -78,6 +78,7 @@ func TestLogFunctions(t *testing.T) {
 	l.Trace(time.Now().String())
 	l.Warn(time.Now().String())
 	l.Error(time.Now().String())
+	l.Errorf("%v", time.Now().String())
 	l.Critical(time.Now().String())
 
 }


### PR DESCRIPTION
brings logger.go test coverage to 100%.

If not merged, please provide feedback.