### PR TITLE
need to be sure and import command to init all the backend commands

### DIFF
--- a/frontend/qml/main.go
+++ b/frontend/qml/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"github.com/limetext/gopy/lib"
 	"github.com/limetext/lime/backend"
+	_ "github.com/limetext/lime/backend/commands"
 	"github.com/limetext/lime/backend/log"
 	"github.com/limetext/lime/backend/textmate"
 	"gopkg.in/qml.v1"


### PR DESCRIPTION
TIL about imports using the _ operator. I had removed the command import because i thought it wasn't being used. Turns out we definitely need it in order to initialize all the commands. 

Without this fix, you can't type anything into the QML editor.

What I don't understand is why this needs to be imported in the frontend. Can't this be added to a single place in the backend code, so the frontends don't have to worry about it?
