### PR TITLE
OSX font is "Menlo", not "Menlo Regular"

### DIFF
--- a/packages/Default/Preferences (OSX).sublime-settings
+++ b/packages/Default/Preferences (OSX).sublime-settings
@@ -1,4 +1,4 @@
 {
-	"font_face": "Menlo Regular",
+	"font_face": "Menlo",
 	"font_size": 12
 }


### PR DESCRIPTION
this fixes helvetica showing up as the monospace font for OSX.