### PR TITLE
Amend to backward compatibility with compiler 1.3.3

### DIFF
--- a/frontend/termbox/main.go
+++ b/frontend/termbox/main.go
@@ -511,7 +511,7 @@ func (t *tbfe) renderthread() {
 		termbox.Flush()
 	}
 
-	for range t.dorender {
+	for _ = range t.dorender {
 		dorender()
 	}
 }
@@ -589,7 +589,7 @@ func (t *tbfe) loop() {
 		}()
 
 		go func() {
-			for range timer.C {
+			for _ = range timer.C {
 				timechan <- true
 				timer.Reset(duration)
 			}


### PR DESCRIPTION
Hi. 
I have changed small piece of code to make available compile lime under 1.3.3 version of compiler, which is distributed with Ubuntu 15.04(64bit). I've tested it also in 1.4 version and seem okay.
This is my first pull request so please be understanding if I did something wrong.
Regards.